### PR TITLE
Add offset attribute to TimeSeries

### DIFF
--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -124,6 +124,15 @@ groups:
         acquisition system gain is 8000X, then the 'conversion' multiplier to get from
         raw data acquisition values to recorded volts is 2.5/32768/8000 = 9.5367e-9.
       required: false
+   - name: offset
+      dtype: float32
+      default_value: 0.0
+      doc: Scalar to add to the data after scaling by 'conversion' to finalize its coercion
+        to the specified 'unit'. Two common examples of this include (a) data stored in an
+        unsigned type that requires a shift after scaling to re-center the data,
+        and (b) specialized recording devices that naturally cause a scalar offset with
+        respect to the true units.
+      required: false
     - name: resolution
       dtype: float32
       default_value: -1.0


### PR DESCRIPTION
## Summary of changes

Sister PR to https://github.com/NeurodataWithoutBorders/pynwb/pull/1424, this suggests adding an `offset` attribute to all `TimeSeries` objects for additional support in converting data storage into proper units.

To convert the TimeSeries data field to the specified units, one would perform the operation

```python
data_in_units = data_in_storage * conversion + offset
```

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/format/source/conf.py`, `core/nwb.namespace.yaml`, and `/core/nwb.file.yaml`
  to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
